### PR TITLE
Missing Letter on a Hyperlink :(

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ When the original mod implement their fixes, we disable ours.
 
 ## 📦 Installation
 
-Mod is available on [CurseForge](https://www.curseforge.com/minecraft/mc-mods/altheleaks).
+Mod is available on [CurseForge](https://www.curseforge.com/minecraft/mc-mods/alltheleaks).
 
 ## 🔧 Usage
 


### PR DESCRIPTION
You forgor a letter making the curseforge hyperlink go to a 404 page ☠️ ☠️ ☠️ 