### PR TITLE
Fix cast to EventBus

### DIFF
--- a/src/main/java/dev/uncandango/alltheleaks/leaks/common/mods/neoforge/Issue1486.java
+++ b/src/main/java/dev/uncandango/alltheleaks/leaks/common/mods/neoforge/Issue1486.java
@@ -29,12 +29,14 @@ public class Issue1486 {
 
 	public Issue1486() {
 		var gameBus = NeoForge.EVENT_BUS;
-		gameBus.addListener(EventPriority.LOWEST, this::rebuildListenersCache);
+		if (gameBus instanceof EventBus) {
+			gameBus.addListener(EventPriority.LOWEST, this::rebuildListenersCache);
+		}
 	}
 
 	private void rebuildListenersCache(ServerStoppedEvent event) {
-		var locker = LISTENER_LIST.get(NeoForge.EVENT_BUS);
 		try {
+			var locker = LISTENER_LIST.get(NeoForge.EVENT_BUS);
 			Map<Class<?>, ListenerList> map = (Map<Class<?>, ListenerList>) GET_READ_MAP.invoke(locker);
 			for (var listener : map.values()) {
 				boolean rebuild = (boolean) REBUILD.get(listener);


### PR DESCRIPTION
Hello 👋 

AllTheLeaks generates the following error on server shutdown when SpongeNeo is installed: 

```
java.lang.ClassCastException: Cannot cast org.spongepowered.neoforge.launch.event.NeoEventManager to net.neoforged.bus.EventBus
        at java.base/java.lang.Class.cast(Class.java:4067)
        at java.base/java.lang.invoke.VarHandleReferences$FieldInstanceReadOnly.get(VarHandleReferences.java:92)
        at TRANSFORMER/alltheleaks@0.1.14-beta+1.21.1-neoforge/dev.uncandango.alltheleaks.leaks.common.mods.neoforge.Issue1486.rebuildListenersCache(Issue1486.java:36)
        at MC-BOOTSTRAP/net.neoforged.bus/net.neoforged.bus.ConsumerEventHandler.invoke(ConsumerEventHandler.java:26)
        at MC-BOOTSTRAP/net.neoforged.bus/net.neoforged.bus.EventBus.post(EventBus.java:350)
        at MC-BOOTSTRAP/net.neoforged.bus/net.neoforged.bus.EventBus.post(EventBus.java:315)
        at TRANSFORMER/spongeneo@1.21.1-21.1.35-12.0.2-RC0/org.spongepowered.neoforge.launch.event.SpongeEventBus.post(SpongeEventBus.java:52)
        at TRANSFORMER/spongeneo@1.21.1-21.1.35-12.0.2-RC0/org.spongepowered.neoforge.launch.event.NeoEventManager.post(NeoEventManager.java:114)
        at TRANSFORMER/neoforge@21.1.93/net.neoforged.neoforge.server.ServerLifecycleHooks.handleServerStopped(ServerLifecycleHooks.java:127)
        at TRANSFORMER/minecraft@1.21.1/net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:750)
        at TRANSFORMER/minecraft@1.21.1/net.minecraft.server.MinecraftServer.lambda$spin$2(MinecraftServer.java:267)
        at java.base/java.lang.Thread.run(Thread.java:1583)
```

The `NeoForge.EVENT_BUS` is typed `IEventBus` but the reflection code assumes that the instance is always an `EventBus` which is not the case when SpongeNeo is installed. 

This small PR fixes that.